### PR TITLE
Creating RAID Request Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/raid-request.md
+++ b/.github/ISSUE_TEMPLATE/raid-request.md
@@ -27,6 +27,8 @@ _below are the reference amounts on initial distrobution_
 | raider | $20,461.73 | $110,497.78   | $140,236.71   | $231,747.54   | $2,139,420.74 |
 | client | $62,878.40 | $62,878.40    | $188,635.19   | $314,391.98   | $691,662.35   |
 
+## Address to receive the RAID
+
 ## Request Type
 _mark all that apply_
 - [ ] RAID Correction (fixing a mistake made on the drop)

--- a/.github/ISSUE_TEMPLATE/raid-request.md
+++ b/.github/ISSUE_TEMPLATE/raid-request.md
@@ -1,0 +1,31 @@
+---
+name: RAID Request
+about: Request a amount of RAID
+title: ''
+labels: RAID-Req
+assignees: ''
+---
+
+# Request Name
+
+### Request Submitted By
+
+Your Name
+
+## Summary
+
+This is a quick summary of why we should be sending raid.
+
+## Amount of RAID Request (in RAID)
+
+\$5000
+
+## Request Type
+_mark all that apply_
+- [ ] RAID Correction (fixing a mistake made on the drop)
+- [ ] RAID Reward (rewarding community with RAID)
+- [ ] RAID Retro (was not part of the initial drop but should've been)
+
+## Anything else you'd like to add?
+
+Not at this time.

--- a/.github/ISSUE_TEMPLATE/raid-request.md
+++ b/.github/ISSUE_TEMPLATE/raid-request.md
@@ -20,7 +20,7 @@ This is a quick summary of why we should be sending raid.
 
 \$5000
 
-_below are the reference amounts on initial distrobution_
+_below are the reference amounts on initial distribution
 
 | type   | min        | 25 percentile | 50 percentile | 75 percentile | max           |
 |--------|------------|---------------|---------------|---------------|---------------|

--- a/.github/ISSUE_TEMPLATE/raid-request.md
+++ b/.github/ISSUE_TEMPLATE/raid-request.md
@@ -20,6 +20,13 @@ This is a quick summary of why we should be sending raid.
 
 \$5000
 
+_below are the reference amounts on initial distrobution_
+
+| type   | min        | 25 percentile | 50 percentile | 75 percentile | max           |
+|--------|------------|---------------|---------------|---------------|---------------|
+| raider | $20,461.73 | $110,497.78   | $140,236.71   | $231,747.54   | $2,139,420.74 |
+| client | $62,878.40 | $62,878.40    | $188,635.19   | $314,391.98   | $691,662.35   |
+
 ## Request Type
 _mark all that apply_
 - [ ] RAID Correction (fixing a mistake made on the drop)


### PR DESCRIPTION
We've received multiple requests on RAID token requests for both clients and internal raiders (including cohorts).  For ease, I proposed following a similar process to the RIP process we already setup.  

Having one raider already go through the process seemed as though it'd be easier to create a new issue template for RAID.  This both:
1. Keeps things separate 
2. Provides a template specific to new RAID requests

This is my proposed template for RAID distro requests